### PR TITLE
Clarify CPU Architecture Descriptions

### DIFF
--- a/docs/framework/configure-apps/file-schema/runtime/assemblyidentity-element-for-runtime.md
+++ b/docs/framework/configure-apps/file-schema/runtime/assemblyidentity-element-for-runtime.md
@@ -47,10 +47,10 @@ culture="assembly culture"/>
   
 |Value|Description|  
 |-----------|-----------------|  
-|`amd64`|A 64-bit AMD processor only.|  
-|`ia64`|A 64-bit Intel processor only.|  
-|`msil`|Neutral with respect to processor and bits-per-word|  
-|`x86`|A 32-bit Intel processor, either native or in the Windows on Windows (WOW) environment on a 64-bit platform.|  
+|`amd64`|AMD x86-64 architecture only.|  
+|`ia64`|Intel Itanium architecture only.|  
+|`msil`|Neutral with respect to processor and bits-per-word.|  
+|`x86`|A 32-bit x86 processor, either native or in the Windows on Windows (WOW) environment on a 64-bit platform.|  
   
 ### Child Elements  
  None.  


### PR DESCRIPTION
Clarify misleading architecture descriptions. `amd64` and `ia64` refer to specifications and not a particular brand of CPUs.

Virtually every modern desktop and laptop Intel CPU follows the AMD x86_64 specification and not the Itanium specification. Thus, `assemblyidentity` elements with `processorArchitecture` set to `ia64` are ignored on these machines, meanwhile one with `processorArchitecture` set to `amd64` would be used if present.